### PR TITLE
Untar stripping first folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM tutum/apache-php
 
 ENV PIWIK_VERSION 2.9.1
 
-RUN rm -rf /app
-RUN curl -L -O http://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz
-RUN tar -xzf piwik-${PIWIK_VERSION}.tar.gz
-RUN mv piwik /app
+RUN rm -rf /app/*
+RUN curl -L -O http://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz && \
+    tar --strip 1 -xzf piwik-${PIWIK_VERSION}.tar.gz && \
+    rm piwik-${PIWIK_VERSION}.tar.gz
 RUN chmod a+w /app/tmp && \
     chmod a+w /app/config
 


### PR DESCRIPTION
Resolves build errors of previous versions, maybe introduced through changes in the parent image.
